### PR TITLE
🐛 Fix crash when single : sourrounded by spaces is present in pinyin

### DIFF
--- a/decode_pinyin.py
+++ b/decode_pinyin.py
@@ -19,7 +19,7 @@ def decode_pinyin(s):
     for c in s:
         if c >= 'a' and c <= 'z':
             char += c
-        elif c == ':':
+        elif c == ':' and len(char) > 1:
             assert char[-1] == 'u'
             char = char[:-1] + "\u00fc"
         elif c >= '0' and c <= '5':


### PR DESCRIPTION
Some entries contain a colon surrounded by spaces (` : `) in the pinyin field.

For example: `...dong1 : Xian1...`.

This causes the `decode_pinyin` function to crash. Fix in this PR.